### PR TITLE
Fix tab events not notifying delegate

### DIFF
--- a/Example/BonsplitExample/AppState.swift
+++ b/Example/BonsplitExample/AppState.swift
@@ -95,6 +95,8 @@ extension AppState: BonsplitDelegate {
     func splitTabBar(_ controller: BonsplitController,
                      shouldCloseTab tab: Bonsplit.Tab,
                      inPane pane: PaneID) -> Bool {
+        debugState?.log("🔔 shouldCloseTab: \"\(tab.title)\" in pane \(pane.hashValue)")
+
         // If tab is dirty, show confirmation
         if tab.isDirty {
             let alert = NSAlert()
@@ -109,21 +111,27 @@ extension AppState: BonsplitDelegate {
             case .alertFirstButtonReturn:
                 // Save - in a real app, save the file here
                 print("Saving \(tab.title)...")
+                debugState?.log("   → allowed (saved)")
                 return true
             case .alertSecondButtonReturn:
                 // Don't save - just close
+                debugState?.log("   → allowed (discarded)")
                 return true
             default:
                 // Cancel
+                debugState?.log("   → denied (cancelled)")
                 return false
             }
         }
+        debugState?.log("   → allowed")
         return true
     }
 
     func splitTabBar(_ controller: BonsplitController,
                      didCloseTab tabId: TabID,
                      fromPane pane: PaneID) {
+        debugState?.log("✅ didCloseTab: tab \(tabId.hashValue) from pane \(pane.hashValue)")
+
         // Clean up content when tab is closed
         tabContents.removeValue(forKey: tabId)
         debugState?.refresh()

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -45,7 +45,6 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
             // Tab bar
             TabBarView(
                 pane: pane,
-                controller: controller,
                 isFocused: isFocused,
                 showSplitButtons: showSplitButtons
             )

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -3,8 +3,9 @@ import AppKit
 
 /// Recursively renders a split node (pane or split)
 struct SplitNodeView<Content: View, EmptyContent: View>: View {
+    @Environment(SplitViewController.self) private var controller
+    
     let node: SplitNode
-    let controller: SplitViewController
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     var showSplitButtons: Bool = true
@@ -17,7 +18,6 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
             // Wrap in NSHostingController for proper layout constraints
             SinglePaneWrapper(
                 pane: paneState,
-                controller: controller,
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
                 showSplitButtons: showSplitButtons,
@@ -40,8 +40,9 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
 
 /// Wrapper that uses NSHostingController for proper AppKit layout constraints
 struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable {
+    @Environment(SplitViewController.self) private var controller
+    
     let pane: PaneState
-    let controller: SplitViewController
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     var showSplitButtons: Bool = true

--- a/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 /// Main container view that renders the entire split tree (internal implementation)
 struct SplitViewContainer<Content: View, EmptyContent: View>: View {
-    @Bindable var controller: SplitViewController
+    @Environment(SplitViewController.self) private var controller
+    
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     var showSplitButtons: Bool = true
@@ -35,7 +36,6 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
     private var splitNodeContent: some View {
         SplitNodeView(
             node: controller.rootNode,
-            controller: controller,
             contentBuilder: contentBuilder,
             emptyPaneBuilder: emptyPaneBuilder,
             showSplitButtons: showSplitButtons,

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -3,8 +3,10 @@ import UniformTypeIdentifiers
 
 /// Tab bar view with scrollable tabs, drag/drop support, and split buttons
 struct TabBarView: View {
+    @Environment(BonsplitController.self) private var controller
+    @Environment(SplitViewController.self) private var splitViewController
+    
     @Bindable var pane: PaneState
-    let controller: SplitViewController
     let isFocused: Bool
     var showSplitButtons: Bool = true
 
@@ -23,7 +25,7 @@ struct TabBarView: View {
 
     /// Whether this tab bar should show full saturation (focused or drag source)
     private var shouldShowFullSaturation: Bool {
-        isFocused || controller.dragSourcePaneId == pane.id
+        isFocused || splitViewController.dragSourcePaneId == pane.id
     }
 
     var body: some View {
@@ -107,7 +109,7 @@ struct TabBarView: View {
             },
             onClose: {
                 withAnimation(.easeInOut(duration: TabBarMetrics.closeDuration)) {
-                    controller.closeTab(tab.id, inPane: pane.id)
+                    _ = controller.closeTab(TabID(id: tab.id), inPane: pane.id)
                 }
             }
         )
@@ -119,7 +121,7 @@ struct TabBarView: View {
         .onDrop(of: [.text], delegate: TabDropDelegate(
             targetIndex: index,
             pane: pane,
-            controller: controller,
+            controller: splitViewController,
             dropTargetIndex: $dropTargetIndex
         ))
         .overlay(alignment: .leading) {
@@ -133,8 +135,8 @@ struct TabBarView: View {
 
     private func createItemProvider(for tab: TabItem) -> NSItemProvider {
         // Set drag source for visual feedback
-        controller.draggingTab = tab
-        controller.dragSourcePaneId = pane.id
+        splitViewController.draggingTab = tab
+        splitViewController.dragSourcePaneId = pane.id
 
         let transfer = TabTransferData(tab: tab, sourcePaneId: pane.id.id)
         if let data = try? JSONEncoder().encode(transfer),
@@ -155,7 +157,7 @@ struct TabBarView: View {
             .onDrop(of: [.text], delegate: TabDropDelegate(
                 targetIndex: pane.tabs.count,
                 pane: pane,
-                controller: controller,
+                controller: splitViewController,
                 dropTargetIndex: $dropTargetIndex
             ))
             .overlay(alignment: .leading) {

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -111,7 +111,26 @@ public final class BonsplitController {
     @discardableResult
     public func closeTab(_ tabId: TabID) -> Bool {
         guard let (pane, tabIndex) = findTabInternal(tabId) else { return false }
-
+        return closeTab(tabId, with: tabIndex, in: pane)
+    }
+    
+    /// Close a tab by ID in a specific pane.
+    /// - Parameter tabId: The tab to close
+    /// - Parameter paneId: The pane in which to close the tab
+    public func closeTab(_ tabId: TabID, inPane paneId: PaneID) -> Bool {
+        guard let pane = internalController.rootNode.findPane(paneId),
+              let tabIndex = pane.tabs.firstIndex(where: { $0.id == tabId.id }) else {
+            return false
+        }
+        
+        return closeTab(tabId, with: tabIndex, in: pane)
+    }
+    
+    /// Internal helper to close a tab given its index in a pane
+    /// - Parameter tabId: The tab to close
+    /// - Parameter tabIndex: The position of the tab within the pane
+    /// - Parameter pane: The pane in which to close the tab
+    private func closeTab(_ tabId: TabID, with tabIndex: Int, in pane: PaneState) -> Bool {
         let tabItem = pane.tabs[tabIndex]
         let tab = Tab(from: tabItem)
         let paneId = pane.id

--- a/Sources/Bonsplit/Public/BonsplitView.swift
+++ b/Sources/Bonsplit/Public/BonsplitView.swift
@@ -39,7 +39,6 @@ public struct BonsplitView<Content: View, EmptyContent: View>: View {
 
     public var body: some View {
         SplitViewContainer(
-            controller: controller.internalController,
             contentBuilder: { tabItem, paneId in
                 contentBuilder(Tab(from: tabItem), PaneID(id: paneId.id))
             },
@@ -52,6 +51,8 @@ public struct BonsplitView<Content: View, EmptyContent: View>: View {
                 controller?.notifyGeometryChange(isDragging: isDragging)
             }
         )
+        .environment(controller)
+        .environment(controller.internalController)
     }
 }
 


### PR DESCRIPTION
Fixes #2

# Why

As outlined in #2, delegate notifications were not sent in many cases, because tabs communicated with the internal `SplitViewController` rather than with the `BonsplitController` that takes care of notifications.

# Changes

This PR solves the issue in a minimal way:

- Pass down `BonsplitController` and `SplitViewController` as `@Environment` objects
- Call `BonsplitController` instead of `SplitViewController` when closing tabs

In order to provide an efficient implementation of closing a tab in a known pane, I've added the following `public` function to `BonsplitController`:

- `public func closeTab(_ tabId: TabID, inPane paneId: PaneID) -> Bool`

I've added this second function, because the `closeTab` call with just a `tabId` needs to do more expensive lookups than the `closeTab` call with a known `paneId`.

In order to avoid code duplication, _both_ functions now call a `private` helper method:

- `private func closeTab(_ tabId: TabID, with tabIndex: Int, in pane: PaneState) -> Bool`

Other than that, everything else should work the same.