### PR TITLE
Use dedicated animator instance per controller

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -28,6 +28,8 @@ final class SplitViewController {
 
     /// Callback for geometry changes
     var onGeometryChange: (() -> Void)?
+    
+    let animator: SplitAnimator = SplitAnimator()
 
     init(rootNode: SplitNode? = nil) {
         if let rootNode {

--- a/Sources/Bonsplit/Internal/Utilities/SplitAnimator.swift
+++ b/Sources/Bonsplit/Internal/Utilities/SplitAnimator.swift
@@ -23,14 +23,11 @@ final class SplitAnimator {
     private var displayLink: CVDisplayLink?
     private var animations: [UUID: Animation] = [:]
 
-    /// Shared animator instance
-    static let shared = SplitAnimator()
-
     /// Animation duration in seconds
     nonisolated static let animationDuration: CFTimeInterval = 0.16
     // MARK: - Initialization
 
-    private init() {
+    package init() {
         setupDisplayLink()
     }
 

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -67,11 +67,11 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 splitState.dividerPosition = 0.5
 
                 // Wait for layout
-                DispatchQueue.main.async {
+                Task {
                     // Show the new pane and animate
                     splitView.arrangedSubviews[newPaneIndex].isHidden = false
 
-                    SplitAnimator.shared.animate(
+                    controller.animator.animate(
                         splitView: splitView,
                         from: startPosition,
                         to: targetPosition


### PR DESCRIPTION
## Why

When multiple Bonsplit controllers are used (such as in a macOS multi-window setting), opening new panes doesn't work anymore.

I've tracked this down to the `SplitAnimator` using a `shared` instance across multiple controllers.

## Changes

- Removed `SplitAnimator/shared`
- Added `SplitViewController/animator` property (internal API)
- Modified `SplitContainerView` to use the `animator` instance from the `SplitViewController`, which is obtained from the environment values