### PR TITLE
Honor allowCloseTabs in the tab bar

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -101,6 +101,7 @@ struct TabBarView: View {
         TabItemView(
             tab: tab,
             isSelected: pane.selectedTabId == tab.id,
+            allowsClose: controller.configuration.allowCloseTabs,
             onSelect: {
                 withAnimation(.easeInOut(duration: TabBarMetrics.selectionDuration)) {
                     pane.selectTab(tab.id)

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct TabItemView: View {
     let tab: TabItem
     let isSelected: Bool
+    let allowsClose: Bool
     let onSelect: () -> Void
     let onClose: () -> Void
 
@@ -28,7 +29,9 @@ struct TabItemView: View {
             Spacer(minLength: 4)
 
             // Close button or dirty indicator
-            closeOrDirtyIndicator
+            if allowsClose || tab.isDirty {
+                closeOrDirtyIndicator
+            }
         }
         .padding(.horizontal, TabBarMetrics.tabHorizontalPadding)
         .offset(y: isSelected ? 0.5 : 0)
@@ -94,14 +97,18 @@ struct TabItemView: View {
     private var closeOrDirtyIndicator: some View {
         ZStack {
             // Dirty indicator (shown when dirty and not hovering)
-            if tab.isDirty && !isHovered && !isCloseHovered {
+            if tab.isDirty && (!allowsClose || (!isHovered && !isCloseHovered)) {
                 Circle()
                     .fill(TabBarColors.dirtyIndicator)
                     .frame(width: TabBarMetrics.dirtyIndicatorSize, height: TabBarMetrics.dirtyIndicatorSize)
             }
 
             // Close button (shown on hover)
-            if isHovered || isCloseHovered {
+            if Self.showsCloseButton(
+                allowsClose: allowsClose,
+                isHovered: isHovered,
+                isCloseHovered: isCloseHovered
+            ) {
                 Button {
                     onClose()
                 } label: {
@@ -123,5 +130,13 @@ struct TabItemView: View {
         .frame(width: TabBarMetrics.closeButtonSize, height: TabBarMetrics.closeButtonSize)
         .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: isHovered)
         .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: isCloseHovered)
+    }
+
+    static func showsCloseButton(
+        allowsClose: Bool,
+        isHovered: Bool,
+        isCloseHovered: Bool
+    ) -> Bool {
+        allowsClose && (isHovered || isCloseHovered)
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -60,6 +60,23 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(controller.configuration.allowCloseTabs)
     }
 
+    func testTabCloseButtonVisibilityFollowsConfiguration() {
+        XCTAssertTrue(
+            TabItemView.showsCloseButton(
+                allowsClose: true,
+                isHovered: true,
+                isCloseHovered: false
+            )
+        )
+        XCTAssertFalse(
+            TabItemView.showsCloseButton(
+                allowsClose: false,
+                isHovered: true,
+                isCloseHovered: true
+            )
+        )
+    }
+
     // MARK: - Zoom
 
     @MainActor


### PR DESCRIPTION
## Summary

- pass `allowCloseTabs` through to each tab item
- hide close-button affordances when closing is disabled
- keep dirty indicators visible for non-closeable dirty tabs
- add regression coverage for hover behavior

## Context

`BonsplitConfiguration.allowCloseTabs` already prevents the controller from closing tabs, and the README describes it as controlling close-button visibility. The tab bar still rendered a close button on hover. This change makes the UI follow the configuration as documented.

## Testing

- `DEVELOPER_DIR=/Applications/Xcode-26.6.0.app/Contents/Developer swift test`
- 12 tests passed